### PR TITLE
Feat: multi-team sync — sync multiple Linear teams into separate vault folders

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ A comprehensive Linear integration plugin for Obsidian that provides seamless bi
 - **💡 Interactive Tooltips**: Hover over issue links to see instant previews with actions
 
 ### Advanced Sync Features
+- **🗂️ Multi-team Sync**: Sync multiple Linear teams into separate vault folders simultaneously
 - **⚔️ Intelligent Conflict Resolution**: Smart detection and resolution of sync conflicts
 - **🤖 Auto-fill from Expressions**: Automatically populate issue fields from note content
 - **🏷️ Dynamic Label Creation**: Automatically create new labels when they don't exist
@@ -119,6 +120,36 @@ Type any of the tag prefixes and see instant suggestions:
 - `@status/` → Shows workflow states
 - `@label/` → Shows existing labels with colors
 
+### Multi-team Sync
+
+If you work across multiple Linear teams or projects, you can sync each team into its own vault folder simultaneously.
+
+**Setup:**
+
+1. Open Settings → Linear Integration → **Team Sync** section
+2. Click **+ Add team** — your teams load automatically from Linear
+3. Select a team and set its vault folder (e.g. `Linear Issues/Golden Wealth`)
+4. Repeat for each team
+5. Each team has an enable/disable toggle so you can pause a project without removing it
+6. Run **Sync Linear Issues** — each team's issues appear in their own folder as editable notes
+
+**Example layout:**
+```
+Linear Issues/
+  Golden Wealth/          ← GW team issues
+    GW-1 - Insurance Policy Inventory.md
+    GW-2 - Power of Attorney Builder.md
+    ...
+  Engineering/            ← ENG team issues
+    ENG-42 - Fix login bug.md
+    ...
+  Marketing/              ← MKT team issues
+    MKT-7 - Q3 campaign brief.md
+    ...
+```
+
+Each sync does a full pull per team, so all issues stay current regardless of when you last synced. The legacy single-team **Default Team** + **Sync Folder** settings remain as a fallback when no team sync configs are defined.
+
 ### Local Configuration
 
 Create `.linear.json` files in any folder to customize behavior:
@@ -214,8 +245,9 @@ Available variables:
 | Setting | Description | Default |
 |---------|-------------|---------|
 | **API Key** | Your Linear Personal API Key | - |
-| **Default Team** | Default team for new issues | - |
-| **Sync Folder** | Folder for Linear notes | "Linear Issues" |
+| **Team Sync Configs** | List of teams to sync, each with its own vault folder | [] |
+| **Default Team** | Fallback team for new issues (used when no team sync configs defined) | - |
+| **Sync Folder** | Fallback folder for Linear notes (used when no team sync configs defined) | "Linear Issues" |
 | **Auto Sync** | Sync on startup | false |
 | **Sync Interval** | Minutes between auto-syncs | 15 |
 | **Auto-fill from Expressions** | Parse note content to pre-fill modal | true |

--- a/main.ts
+++ b/main.ts
@@ -123,7 +123,20 @@ export default class LinearPlugin extends Plugin {
             id: 'sync-linear-issues',
             name: 'Sync Linear issues',
             callback: async () => {
-                await this.syncManager.syncAll();
+                new Notice('Syncing Linear issues...');
+                try {
+                    const result = await this.syncManager.syncAll();
+                    const teams = (this.settings.teamSyncConfigs ?? []).filter(c => c.enabled).length;
+                    const teamLabel = teams > 1 ? `${teams} teams` : 'Linear';
+                    new Notice(`✅ ${teamLabel} synced — ${result.created} created, ${result.updated} updated`);
+                    if (result.errors.length > 0) {
+                        new Notice(`⚠️ ${result.errors.length} error(s) during sync — check console`);
+                        debugLog.error('Sync errors:', result.errors);
+                    }
+                } catch (error) {
+                    new Notice(`❌ Sync failed: ${(error as Error).message}`);
+                    debugLog.error('Sync error:', error);
+                }
             }
         });
 

--- a/src/models/types.ts
+++ b/src/models/types.ts
@@ -1,6 +1,17 @@
 import { TFile } from 'obsidian';
+
+export interface TeamSyncConfig {
+    teamId: string;
+    teamName: string;
+    teamKey: string;
+    syncFolder: string;
+    enabled: boolean;
+}
+
 export interface LinearPluginSettings {
     apiKey: string;
+    teamSyncConfigs: TeamSyncConfig[];
+    // Legacy single-team fields kept for backward compatibility
     teamId: string;
     syncFolder: string;
     autoSync: boolean;
@@ -27,6 +38,7 @@ export interface LinearPluginSettings {
 
 export const DEFAULT_SETTINGS: LinearPluginSettings = {
     apiKey: '',
+    teamSyncConfigs: [],
     teamId: '',
     syncFolder: 'Linear Issues',
     autoSync: false,

--- a/src/sync/sync-manager.ts
+++ b/src/sync/sync-manager.ts
@@ -2,7 +2,7 @@ import { debugLog } from '../utils/debug';
 import { getFolderByPath } from '../utils/file-utils';
 import { App, TFile } from 'obsidian';
 import { LinearClient } from '../api/linear-client';
-import { LinearIssue, LinearPluginSettings, NoteFrontmatter, SyncResult } from '../models/types';
+import { LinearIssue, LinearPluginSettings, NoteFrontmatter, SyncResult, TeamSyncConfig } from '../models/types';
 import { parseFrontmatter, updateFrontmatter } from '../utils/frontmatter';
 
 export class SyncManager {
@@ -22,31 +22,52 @@ export class SyncManager {
         };
 
         try {
-            // Ensure sync folder exists
-            await this.ensureSyncFolder();
+            // Build list of team configs to sync
+            const teamConfigs: TeamSyncConfig[] = (this.settings.teamSyncConfigs ?? []).filter(c => c.enabled);
 
-            // Get last sync time
-            const lastSync = await this.getLastSyncTime();
+            // Fall back to legacy single-team config if no multi-team configs defined
+            if (teamConfigs.length === 0 && this.settings.teamId) {
+                teamConfigs.push({
+                    teamId: this.settings.teamId,
+                    teamName: 'Default',
+                    teamKey: '',
+                    syncFolder: this.settings.syncFolder || 'Linear Issues',
+                    enabled: true
+                });
+            }
 
-            // Fetch issues from Linear
-            const issues = await this.linearClient.getIssues(
-                this.settings.teamId || undefined,
-                lastSync
-            );
+            if (teamConfigs.length === 0) {
+                result.errors.push('No teams configured. Add at least one team in plugin settings.');
+                return result;
+            }
 
-            // Process each issue
-            for (const issue of issues) {
+            // For multi-team sync, always do a full pull per team so each team's
+            // folder stays complete regardless of the global lastSyncTime stamp.
+            // For legacy single-team fallback, honour lastSyncTime for incremental sync.
+            const isMultiTeam = (this.settings.teamSyncConfigs ?? []).filter(c => c.enabled).length > 0;
+            const lastSync = isMultiTeam ? undefined : await this.getLastSyncTime();
+
+            // Sync each team into its own folder
+            for (const config of teamConfigs) {
                 try {
-                    const file = await this.findOrCreateNoteForIssue(issue);
-                    const wasCreated = await this.updateNoteWithIssue(file, issue);
-                    
-                    if (wasCreated) {
-                        result.created++;
-                    } else {
-                        result.updated++;
+                    await this.ensureSyncFolder(config.syncFolder);
+                    const issues = await this.linearClient.getIssues(config.teamId, lastSync);
+
+                    for (const issue of issues) {
+                        try {
+                            const file = await this.findOrCreateNoteForIssue(issue, config.syncFolder);
+                            const wasCreated = await this.updateNoteWithIssue(file, issue);
+                            if (wasCreated) {
+                                result.created++;
+                            } else {
+                                result.updated++;
+                            }
+                        } catch (error) {
+                            result.errors.push(`Failed to sync issue ${issue.identifier}: ${(error as Error).message}`);
+                        }
                     }
                 } catch (error) {
-                    result.errors.push(`Failed to sync issue ${issue.identifier}: ${(error as Error).message}`);
+                    result.errors.push(`Failed to sync team "${config.teamName}": ${(error as Error).message}`);
                 }
             }
 
@@ -60,12 +81,11 @@ export class SyncManager {
         return result;
     }
 
-    async findOrCreateNoteForIssue(issue: LinearIssue): Promise<TFile> {
-        //Refactored to avoid type assertion
-        const syncFolder = getFolderByPath(this.app.vault, this.settings.syncFolder);
-        
-        // Try to find existing note by Linear ID
-        for (const file of syncFolder.children) {
+    async findOrCreateNoteForIssue(issue: LinearIssue, syncFolder: string): Promise<TFile> {
+        const folder = getFolderByPath(this.app.vault, syncFolder);
+
+        // Try to find existing note by Linear ID in this folder
+        for (const file of folder.children) {
             if (file instanceof TFile && file.extension === 'md') {
                 const frontmatter = await this.getFrontmatter(file);
                 if (frontmatter.linear_id === issue.id || frontmatter.linear_identifier === issue.identifier) {
@@ -74,10 +94,10 @@ export class SyncManager {
             }
         }
 
-        // Create new note
+        // Create new note in the team's folder
         const filename = this.sanitizeFilename(`${issue.identifier} - ${issue.title}.md`);
-        const filepath = `${this.settings.syncFolder}/${filename}`;
-        
+        const filepath = `${syncFolder}/${filename}`;
+
         const content = this.generateNoteContent(issue);
         return await this.app.vault.create(filepath, content);
     }
@@ -165,10 +185,10 @@ export class SyncManager {
         return yamlLines.join('\n') + content;
     }
 
-    private async ensureSyncFolder(): Promise<void> {
-        const folder = this.app.vault.getAbstractFileByPath(this.settings.syncFolder);
+    private async ensureSyncFolder(syncFolder: string): Promise<void> {
+        const folder = this.app.vault.getAbstractFileByPath(syncFolder);
         if (!folder) {
-            await this.app.vault.createFolder(this.settings.syncFolder);
+            await this.app.vault.createFolder(syncFolder);
         }
     }
 

--- a/src/ui/settings-tab.ts
+++ b/src/ui/settings-tab.ts
@@ -1,7 +1,104 @@
 import { debugLog } from '../utils/debug';
 import { setDefaultOption } from '../utils/dom-utils';
-import { App, PluginSettingTab, Setting, Notice, Modal } from 'obsidian'; 
+import { App, PluginSettingTab, Setting, Notice, Modal } from 'obsidian';
 import LinearPlugin from '../../main';
+import { TeamSyncConfig } from '../models/types';
+
+class AddTeamModal extends Modal {
+    private teamId: string = '';
+    private teamName: string = '';
+    private teamKey: string = '';
+    private syncFolder: string = '';
+    private onSubmit: (config: TeamSyncConfig) => void;
+    private availableTeams: { id: string; name: string; key: string }[] = [];
+
+    constructor(
+        app: App,
+        onSubmit: (config: TeamSyncConfig) => void,
+        availableTeams: { id: string; name: string; key: string }[] = []
+    ) {
+        super(app);
+        this.onSubmit = onSubmit;
+        this.availableTeams = availableTeams;
+    }
+
+    onOpen(): void {
+        const { contentEl } = this;
+        contentEl.empty();
+        new Setting(contentEl).setName('Add team sync').setHeading();
+
+        if (this.availableTeams.length > 0) {
+            new Setting(contentEl)
+                .setName('Team')
+                .setDesc('Select a Linear team to sync')
+                .addDropdown(dropdown => {
+                    dropdown.addOption('', 'Select a team...');
+                    this.availableTeams.forEach(t => dropdown.addOption(t.id, `${t.name} (${t.key})`));
+                    dropdown.onChange(value => {
+                        const team = this.availableTeams.find(t => t.id === value);
+                        if (team) {
+                            this.teamId = team.id;
+                            this.teamName = team.name;
+                            this.teamKey = team.key;
+                            if (!this.syncFolder) {
+                                this.syncFolder = `Linear Issues/${team.name}`;
+                                const folderInput = contentEl.querySelector('input[placeholder*="Linear Issues"]') as HTMLInputElement;
+                                if (folderInput) folderInput.value = this.syncFolder;
+                            }
+                        }
+                    });
+                });
+        } else {
+            new Setting(contentEl)
+                .setName('Team ID')
+                .setDesc('Linear team ID')
+                .addText(text => text
+                    .setPlaceholder('e.g. 3f67f930-...')
+                    .onChange(value => { this.teamId = value; }));
+
+            new Setting(contentEl)
+                .setName('Team name')
+                .addText(text => text
+                    .setPlaceholder('e.g. Golden Wealth')
+                    .onChange(value => { this.teamName = value; }));
+
+            new Setting(contentEl)
+                .setName('Team key')
+                .addText(text => text
+                    .setPlaceholder('e.g. GW')
+                    .onChange(value => { this.teamKey = value; }));
+        }
+
+        new Setting(contentEl)
+            .setName('Sync folder')
+            .setDesc('Vault folder where this team\'s issues will be synced')
+            .addText(text => {
+                text.setPlaceholder('Linear Issues/Golden Wealth')
+                    .setValue(this.syncFolder)
+                    .onChange(value => { this.syncFolder = value; });
+                return text;
+            });
+
+        const buttonContainer = contentEl.createDiv({ cls: 'modal-button-container' });
+        const addButton = buttonContainer.createEl('button', { text: 'Add team', cls: 'mod-cta' });
+        addButton.onclick = () => this.submit();
+        const cancelButton = buttonContainer.createEl('button', { text: 'Cancel' });
+        cancelButton.onclick = () => this.close();
+    }
+
+    private submit(): void {
+        if (!this.teamId || !this.teamName || !this.syncFolder) {
+            new Notice('Please fill in all fields');
+            return;
+        }
+        this.onSubmit({ teamId: this.teamId, teamName: this.teamName, teamKey: this.teamKey, syncFolder: this.syncFolder, enabled: true });
+        this.close();
+    }
+
+    onClose(): void {
+        this.contentEl.empty();
+    }
+}
 
 class StatusMappingModal extends Modal {
     private statusName: string = '';
@@ -180,35 +277,99 @@ export class LinearSettingsTab extends PluginSettingTab {
                     }
                 }));
 
-        // Team selection
+
+        // ── Multi-team sync configuration ──────────────────────────────────────
+        new Setting(containerEl).setName('Team sync').setHeading();
         new Setting(containerEl)
-            .setName('Default team')
-            .setDesc('Select the Linear team to sync with')
-            .addDropdown(dropdown => {
-                dropdown.addOption('', 'Select a team...');
-                dropdown.setValue(this.plugin.settings.teamId);
-                dropdown.onChange(async (value) => {
-                    this.plugin.settings.teamId = value;
-                    await this.plugin.saveSettings();
+            .setName('Team sync configurations')
+            .setDesc('Sync multiple Linear teams into separate vault folders. Each team gets its own folder.');
+
+        const configs = this.plugin.settings.teamSyncConfigs ?? [];
+
+        if (configs.length === 0) {
+            containerEl.createEl('p', {
+                text: 'No teams configured. Add a team below.',
+                cls: 'setting-item-description'
+            });
+        }
+
+        configs.forEach((config, index) => {
+            const setting = new Setting(containerEl)
+                .setName(`${config.teamName} (${config.teamKey || config.teamId.slice(0, 8)})`)
+                .setDesc(`→ ${config.syncFolder}`)
+                .addToggle(toggle => toggle
+                    .setValue(config.enabled)
+                    .setTooltip('Enable/disable sync for this team')
+                    .onChange(async (value) => {
+                        this.plugin.settings.teamSyncConfigs[index].enabled = value;
+                        await this.plugin.saveSettings();
+                    }))
+                .addButton(button => button
+                    .setButtonText('Remove')
+                    .setWarning()
+                    .onClick(async () => {
+                        this.plugin.settings.teamSyncConfigs.splice(index, 1);
+                        await this.plugin.saveSettings();
+                        this.display();
+                    }));
+            setting.settingEl.style.borderLeft = config.enabled ? '3px solid var(--interactive-accent)' : '3px solid var(--background-modifier-border)';
+        });
+
+        new Setting(containerEl)
+            .setName('Add team')
+            .setDesc('Add a new team to sync')
+            .addButton(button => button
+                .setButtonText('+ Add team')
+                .setCta()
+                .onClick(async () => {
+                    let teams: { id: string; name: string; key: string }[] = [];
+                    if (this.plugin.settings.apiKey) {
+                        try {
+                            teams = await this.plugin.linearClient.getTeams();
+                        } catch {
+                            // proceed without team list
+                        }
+                    }
+                    new AddTeamModal(this.app, async (config) => {
+                        if (!this.plugin.settings.teamSyncConfigs) {
+                            this.plugin.settings.teamSyncConfigs = [];
+                        }
+                        this.plugin.settings.teamSyncConfigs.push(config);
+                        await this.plugin.saveSettings();
+                        new Notice(`✅ Added team "${config.teamName}" → ${config.syncFolder}`);
+                        this.display();
+                    }, teams).open();
+                }));
+
+        // ── Legacy single-team fallback (shown only when no multi-team configs) ──
+        if (configs.length === 0) {
+            new Setting(containerEl).setName('Legacy fallback').setHeading();
+            new Setting(containerEl)
+                .setName('Default team')
+                .setDesc('Used only when no team sync configs are defined above')
+                .addDropdown(dropdown => {
+                    dropdown.addOption('', 'Select a team...');
+                    dropdown.setValue(this.plugin.settings.teamId);
+                    dropdown.onChange(async (value) => {
+                        this.plugin.settings.teamId = value;
+                        await this.plugin.saveSettings();
+                    });
+                    if (this.plugin.settings.apiKey) {
+                        this.loadTeamsIntoDropdown(dropdown);
+                    }
                 });
 
-                // Load teams if API key is available
-                if (this.plugin.settings.apiKey) {
-                    this.loadTeamsIntoDropdown(dropdown);
-                }
-            });
-
-        // Sync folder setting
-        new Setting(containerEl)
-            .setName('Sync folder')
-            .setDesc('Folder where Linear issues will be synced')
-            .addText(text => text
-                .setPlaceholder('Linear Issues')
-                .setValue(this.plugin.settings.syncFolder)
-                .onChange(async (value) => {
-                    this.plugin.settings.syncFolder = value;
-                    await this.plugin.saveSettings();
-                }));
+            new Setting(containerEl)
+                .setName('Sync folder')
+                .setDesc('Folder where Linear issues will be synced (legacy single-team)')
+                .addText(text => text
+                    .setPlaceholder('Linear Issues')
+                    .setValue(this.plugin.settings.syncFolder)
+                    .onChange(async (value) => {
+                        this.plugin.settings.syncFolder = value;
+                        await this.plugin.saveSettings();
+                    }));
+        }
 
         new Setting(containerEl).setName('Synchronization').setHeading();
 


### PR DESCRIPTION
Closes #2

## Problem

The plugin previously supported only a single Linear team synced into a single vault folder. Users working across multiple projects had to manually swap the default team setting and re-sync each time — making Obsidian impractical as a primary workspace for multi-project workflows.

## Solution

This PR adds a `teamSyncConfigs[]` setting that lets users configure any number of Linear teams, each mapped to its own vault folder. A single **Sync Linear Issues** command syncs all enabled teams in one operation.

**Example vault layout after sync:**
```
Linear Issues/
  Golden Wealth/
    GW-1 - Insurance Policy Inventory.md
    GW-2 - Power of Attorney Builder.md
  Engineering/
    ENG-42 - Fix login bug.md
  Marketing/
    MKT-7 - Q3 campaign brief.md
```

## Changes

### `src/models/types.ts`
- New `TeamSyncConfig` interface (`teamId`, `teamName`, `teamKey`, `syncFolder`, `enabled`)
- Added `teamSyncConfigs: TeamSyncConfig[]` to `LinearPluginSettings`
- Legacy `teamId` + `syncFolder` fields retained as fallback

### `src/sync/sync-manager.ts`
- `syncAll()` loops over enabled team configs, syncing each into its designated folder
- Falls back to legacy single-team config when `teamSyncConfigs` is empty
- Multi-team mode skips `lastSyncTime` filter so all issues are always fully present per folder
- `ensureSyncFolder()` and `findOrCreateNoteForIssue()` now accept folder path as a parameter

### `src/ui/settings-tab.ts`
- New **Team sync** section showing all configured teams with per-row enable toggle and remove button
- **+ Add team** modal auto-loads available teams from the Linear API for easy selection
- Legacy Default Team + Sync Folder settings shown only when no team configs are defined

### `main.ts`
- `sync-linear-issues` command now shows toast notifications: "Syncing..." on start, count summary on completion, and error count if anything fails

### `README.md`
- New **Multi-team Sync** section with setup steps and example folder layout
- `teamSyncConfigs` added to the settings reference table

## Backward Compatibility & Migration

**No action required for existing users:** If `teamSyncConfigs` is empty (the default), the plugin falls back to the legacy `teamId` + `syncFolder` behavior with no change in behavior.

**Migrating to multi-team sync:** When a user adds team sync configs, new notes are created in the configured subfolder. However, `findOrCreateNoteForIssue` only searches within the new team folder — so **existing notes in the old flat folder will not be found and duplicates will be created**. Users migrating from single-team to multi-team should either:
1. Manually move their existing notes into the new subfolder before running sync, OR
2. Delete the old notes after verifying the new copies are correct

A future improvement could be a one-time migration helper that moves existing Linear notes into the appropriate team subfolder automatically. Happy to add that if the maintainer considers it a blocker.

## Testing

Tested with 2 teams (Golden Wealth + RB Code Labs) syncing 35 and 4 issues respectively into separate vault folders. Verified:
- Issues create as individual `.md` notes with correct frontmatter
- Re-sync updates existing notes without clobbering user-edited content
- Enable/disable toggle per team works correctly
- Removing a team config works correctly
- Legacy single-team mode unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)